### PR TITLE
Granular per-channel configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,13 @@ A simple, lightweight Twitch chatbot that learns from chat messages and generate
 
 ## Configuration
 
-The bot can be configured using a `.env` file or via environment variables.
+The bot can be configured using a `.env` file or via environment variables. 
+
+In addition, channels are managed via a configuration file to allow better customization of behaviour in different channels.
+
+### Env Variables
+
+Here's a table with all the environment variables required to run this properly:
 
 | ENV Variable | Description | Example |
 | -------- | ------- | --- |
@@ -35,10 +41,32 @@ The bot can be configured using a `.env` file or via environment variables.
 | `IGNORE_PARROTS` | Flag to ignore users who copy the last bot's messages. Prevent learning from the bot's own gibberish. | `"true"`/`"false"` |
 | `TWITCH_USER` | Username of the account which this bot operates under. | `"a_c_a_c"` |
 | `TWITCH_OAUTH_STRING` | Your account's oauth string to authenticate with twitch chat. | `"oauth:123123123123123"` |
-| `TWITCH_CHANNELS` | Comma separated list of twitch channels to connect to. Every channel gets their own message db and as a result, their own "chat personality". | `"bozo,thelegend27"` |
-| `TWITCH_BOT_USERNAMES` | Comma separated list of twitch bot in the channel. Bot users are added to the ignore list. | `"nightbot,myownbot,funtoon"` |
 | `PROHIBITED_STRINGS` | Comma separated list of strings that will not be sent by the bot. Use this to filter out links, user mentions, etc. | `"https://,twitch.tv,@"` |
 | `PROHIBITED_MESSAGES` | Comma separated list of messages that will not be sent by the bot. Use this to filter out full messages that should not be sent. | `"acac"` |
+| `CHANNEL_CONFIG` | Path to channels configuration file. See `Channel Configuration File` section bellow. | `"./channels.yaml"` |
+
+### Channel Configuration File
+
+The configuration file defines how a_c_a_c behaves across different Twitch channels. It includes a global list of bot usernames to ignore . This prevents the bot from mimicking repetitive, bot-like behavior and ensures cleaner, more human-like interactions.
+
+Each channel entry can specify its own settings, such as message frequency, whether to respond to bits, and additional bots to ignore. Any omitted settings will fall back to sensible defaults—for example, frequency defaults to the value of the COUNTDOWN environment variable, and allow_bits defaults to false.
+
+See also: [Example config file](./example-channels.yaml)
+
+```yaml
+bots:
+  - "nightbot"
+  - "streamerelements"
+
+channels:
+  - name: my_favorite_streamer
+    frequency: 200
+    allow_bits: true
+    extra_bots:
+      - "mod_helper"
+      - "my_favorite_moderation_bot"
+  - name: "streamer_two"
+```
 
 ## Usage
 

--- a/example-channels.yaml
+++ b/example-channels.yaml
@@ -1,0 +1,15 @@
+bots:
+  - "nightbot"
+  - "streamerelements"
+channels:
+  - name: my_favorite_streamer
+    frequency: 200
+    allow_bits: true
+    extra_bots:
+      - "mod_helper"
+  - name: "smalltime_streamer"
+    frequency: 25
+    allow_bits: false
+    extra_bots: []
+  - name: "streamer"
+

--- a/go.mod
+++ b/go.mod
@@ -6,4 +6,5 @@ require (
 	github.com/gempir/go-twitch-irc/v4 v4.2.0
 	github.com/joho/godotenv v1.5.1
 	github.com/mb-14/gomarkov v0.0.0-20231120193207-9cbdc8df67a8
+	gopkg.in/yaml.v3 v3.0.1
 )

--- a/go.sum
+++ b/go.sum
@@ -4,3 +4,7 @@ github.com/joho/godotenv v1.5.1 h1:7eLL/+HRGLY0ldzfGMeQkb7vMd0as4CfYvUVzLqw0N0=
 github.com/joho/godotenv v1.5.1/go.mod h1:f4LDr5Voq0i2e/R5DDNOoa2zzDfwtkZa6DnEwAbqwq4=
 github.com/mb-14/gomarkov v0.0.0-20231120193207-9cbdc8df67a8 h1:4Z2WmWiMrfaZZYbuw5vx1yv1jfgtf5fuRgSUSxhTy5A=
 github.com/mb-14/gomarkov v0.0.0-20231120193207-9cbdc8df67a8/go.mod h1:6nnTLIXjtAZzRGji0HC3vH+rGM2rKdAkIKgizGlRF6g=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/main.go
+++ b/main.go
@@ -49,7 +49,7 @@ func main() {
 
 		if ENV != "production" {
 			fmt.Println("Environment: ", ENV)
-			fmt.Println("Channel: ", GREEN, channel, RESET)
+			fmt.Println("Channel: ", GREEN, fmt.Sprintf("%+v", channel), RESET)
 			fmt.Println("Base path: ", BASE_PATH)
 			fmt.Println("Saving chat messages to: ", savedMessagesFilepath)
 			fmt.Println("Saving sent messages to: ", sentMessagesFilepath)

--- a/pkg/config/channel.go
+++ b/pkg/config/channel.go
@@ -1,0 +1,64 @@
+package config
+
+import (
+	"fmt"
+	"os"
+	"strconv"
+
+	"gopkg.in/yaml.v3"
+)
+
+type ChannelConfig struct {
+	Bots     []string  `yaml:"bots"`
+	Channels []Channel `yaml:"channels"`
+}
+
+type Channel struct {
+	Name      string   `yaml:"name"`
+	Frequency int      `yaml:"frequency"`
+	AllowBits bool     `yaml:"allow_bits"`
+	ExtraBots []string `yaml:"extra_bots"`
+}
+
+func LoadChannelConfig(path string) (cfg ChannelConfig, err error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return cfg, fmt.Errorf("failed to read config file %s: %v", path, err)
+	}
+
+	if err := yaml.Unmarshal(data, &cfg); err != nil {
+		return cfg, fmt.Errorf("failed to parse config file %s: %v", path, err)
+	}
+
+	defaultFrequency, err := GetDefaultFrequency()
+	if err != nil {
+		return cfg, fmt.Errorf("failed to get default chat frequency: %v", err)
+	}
+
+	// Apply defaults
+	for i := range cfg.Channels {
+		ch := &cfg.Channels[i]
+
+		if ch.Name == "" {
+			return cfg, fmt.Errorf("channel name is required")
+		}
+
+		if ch.Frequency == 0 {
+			ch.Frequency = defaultFrequency
+		}
+
+		if ch.ExtraBots == nil {
+			ch.ExtraBots = []string{}
+		}
+	}
+
+	fmt.Printf("Parsed config:\n%+v\n", cfg)
+
+	return cfg, nil
+}
+
+func GetDefaultFrequency() (int, error) {
+	COUNTDOWN := os.Getenv("COUNTDOWN")
+	countdownInterval, err := strconv.Atoi(COUNTDOWN)
+	return countdownInterval, err
+}


### PR DESCRIPTION
Instead of using a list of channels, uses a `yaml` config file to allow settings more granular parameters on a per-channel basis.

Yaml config file is also easier to make automate using automation 